### PR TITLE
Extend correct document class in email hardlink wrapper

### DIFF
--- a/models/Document/Hardlink/Wrapper/Email.php
+++ b/models/Document/Hardlink/Wrapper/Email.php
@@ -22,7 +22,7 @@ use Pimcore\Model;
 /**
  * @method \Pimcore\Model\Document\Hardlink\Dao getDao()
  */
-class Email extends Model\Document\Hardlink implements Model\Document\Hardlink\Wrapper\WrapperInterface
+class Email extends Model\Document\Email implements Model\Document\Hardlink\Wrapper\WrapperInterface
 {
     use Model\Document\Hardlink\Wrapper;
 }


### PR DESCRIPTION
In my opinion this class should extend the email document class, as all the other wrapper classes extend their own base document class too.

The current state causes errors if you want to call an email document via hardlinks. The problem is that "isDirectRouteDocument()" will always return false because it doesn't extend the PageSnippet class (pimcore/lib/Routing/Dynamic/DocumentRouteHandler.php:361).

Because of that the route never gets assigned the _controller attribute and therefore the page can't be rendered in the frontend and throws the following error:

<img width="1053" alt="Bildschirmfoto 2020-09-24 um 10 17 21" src="https://user-images.githubusercontent.com/71453521/94119392-27b0ef80-fe4f-11ea-9519-928df1e05913.png">
